### PR TITLE
Finish step 0 - Stop modifying risk if no new trades

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -15,7 +15,7 @@ int RiskTracker::updateRisk() {
             runningSum -= (x.price * x.quantity);
         }
     }
-    this->totalRisk += runningSum;
+    this->totalRisk = runningSum;
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -19,6 +19,17 @@ TEST(TradeRiskTrackerTest, TrackerInit) {
     EXPECT_NEAR(riskTracker.getRisk(), 21.7, 1e-4);
 }
 
+TEST(TradeRiskTrackerTest, RiskDoesntChangeWithNoNewTrades) {
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    Trade testTrade3(14, true, 1.55);
+    riskTracker.addTrade(testTrade3);
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 21.7, 1e-4);
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 21.7, 1e-4);
+}
+
 TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     std::vector<Trade> trackedTrades;
     RiskTracker riskTracker(0, trackedTrades);


### PR DESCRIPTION
1. What is the purpose of this PR?
This PR fixes a bug that was resulting in the risk changing when there are no new pending trades.
2. What changes did you make? Why?
I changed the risk calculation in RiskTracker::updateRisk to not accumulate to RiskTracker.totalRisk and instead overwrite it. Since, with this risk algorithm, all that is needed to calculate risk is a snapshot of the current trades; there is no need to depend on previous risk values and the previous method was causing risk to grow or shrink incorrectly.
3. What bugs did you find while testing?
Risk was changing without new trades being added.

This PR Specific:
1. What was the bug you found?
Risk was changing without new trades being added.
2. How did you address it?
I changed the risk calculation algorithm in RiskTracker::updateRisk.
3. What did you struggle with?
Identifying the bug.
4. Is there anything you would change about this step?
The risk calculation algorithm is very naive and could be improved to simulate a more realistic market.
